### PR TITLE
use config port first since PORT env variable is set to 80 by AWS

### DIFF
--- a/middleware/middleware.js
+++ b/middleware/middleware.js
@@ -19,7 +19,7 @@ module.exports = function (Q, _, Hapi, pancakes, log, config, chainPromises) {
      */
     function getServer(container) {
         var server = new Hapi.Server();
-        server.connection({ port: process.env.PORT || config[container].port });
+        server.connection({ port: config[container].port || process.env.PORT });
         return server;
     }
 


### PR DESCRIPTION
AWS sets the PORT environment variable to 80 -- doesn't matter if you set it in OpsWorks.  Took a while to figure this out, but by switching the order, we can avoid nginx and node both listening to 80.
